### PR TITLE
Fix loading of local grunt on windows

### DIFF
--- a/lib/gruntfile-runner.coffee
+++ b/lib/gruntfile-runner.coffee
@@ -44,9 +44,8 @@ class GruntfileRunner
       for arg in extraArgs.split ' '
         args.push arg
 
-    process.env.PATH = switch process.platform
-      when 'win32' then process.env.PATH
-      else "#{process.env.PATH}:/usr/local/bin"
+    if process.platform != 'win32'
+      process.env.PATH = "#{process.env.PATH}:/usr/local/bin"
 
     options =
       env: process.env


### PR DESCRIPTION
Edit test to rewrite process.env.PATH only on platform which aren't win32.
